### PR TITLE
fix: support interceptor-set responses in getBody method

### DIFF
--- a/example/src/app.controller.ts
+++ b/example/src/app.controller.ts
@@ -64,6 +64,11 @@ export class AppController {
     return this.appService.getHello();
   }
 
+  @Get('/catch-error')
+  catchError() {
+    throw new Error('Some error');
+  }
+
   @Get('/error')
   error(@Res() res: Context) {
     res.res = res.body('Error', 404);
@@ -93,8 +98,17 @@ export class AppController {
     return `User ${userId}`;
   }
 
+  @Get('/custom-response')
+  customResponse(@Res() ctx: Context) {
+    ctx.res.headers.set('X-Custom-Header', 'CustomValue');
+    ctx.res = new Response('Custom Response Body', {
+      status: 202,
+      headers: ctx.res.headers,
+    });
+  }
+
   @Get('/ip')
-  getIP(@Ip() ip: string): string {
+  getIP(@Ip() ip: string) {
     return `IP ${ip}`;
   }
 
@@ -128,9 +142,17 @@ export class AppController {
   async streamBuffer(@Res() ctx: Context) {
     const file = Bun.file(process.cwd() + '/images/j.jpeg');
     const buffer = await file.bytes();
+    ctx.res.headers.set('Content-Type', 'image/jpeg');
     ctx.res = stream(ctx, async (stream) => {
       await stream.write(buffer);
     });
+  }
+
+  @Get('/bytes')
+  async bytes() {
+    const file = Bun.file(process.cwd() + '/images/j.jpeg');
+
+    return file.bytes();
   }
 
   @Get('/stream')

--- a/example/src/main.ts
+++ b/example/src/main.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { HttpAdapterHost, NestFactory } from '@nestjs/core';
 
 import { HonoAdapter } from '../../src/adapters';
@@ -31,6 +32,8 @@ async function bootstrap() {
   );
 
   await app.listen(3000);
+
+  Logger.log(`Application is running on: http://localhost:3000`);
 }
 bootstrap();
 

--- a/src/adapters/hono-adapter.ts
+++ b/src/adapters/hono-adapter.ts
@@ -80,6 +80,10 @@ export class HonoAdapter extends AbstractHttpAdapter<
   private async getBody(ctx: Ctx, body?: Data) {
     ctx = await this.normalizeContext(ctx);
 
+    if (body === undefined && ctx.res && ctx.res.body !== null) {
+      return ctx.res;
+    }
+
     let responseContentType = await this.getHeader(ctx, 'Content-Type');
 
     if (!responseContentType || responseContentType.startsWith('text/plain')) {

--- a/src/adapters/hono-adapter.ts
+++ b/src/adapters/hono-adapter.ts
@@ -11,6 +11,7 @@ import {
   NestApplicationOptions,
   RequestHandler,
 } from '@nestjs/common/interfaces';
+import { isObject } from '@nestjs/common/utils/shared.utils';
 import { AbstractHttpAdapter } from '@nestjs/core/adapters/http-adapter';
 import { Context, Next, Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
@@ -24,9 +25,17 @@ import * as https from 'https';
 import { HonoRequest, TypeBodyParser } from '../interfaces';
 
 type HonoHandler = RequestHandler<HonoRequest, Context>;
-
 type ServerType = http.Server | http2.Http2Server | http2.Http2SecureServer;
 type Ctx = Context | (() => Promise<Context>);
+type Method =
+  | 'all'
+  | 'get'
+  | 'post'
+  | 'put'
+  | 'delete'
+  | 'use'
+  | 'patch'
+  | 'options';
 
 /**
  * Adapter for using Hono with NestJS.
@@ -87,19 +96,21 @@ export class HonoAdapter extends AbstractHttpAdapter<
     let responseContentType = await this.getHeader(ctx, 'Content-Type');
 
     if (!responseContentType || responseContentType.startsWith('text/plain')) {
-      if (body instanceof Buffer) {
+      if (
+        body instanceof Buffer ||
+        body instanceof Uint8Array ||
+        body instanceof ArrayBuffer ||
+        body instanceof ReadableStream
+      ) {
         responseContentType = 'application/octet-stream';
-      } else if (typeof body === 'object') {
+      } else if (isObject(body)) {
         responseContentType = 'application/json';
       }
 
-      this.setHeader(ctx, 'Content-Type', responseContentType);
+      await this.setHeader(ctx, 'Content-Type', responseContentType);
     }
 
-    if (
-      responseContentType === 'application/json' &&
-      typeof body === 'object'
-    ) {
+    if (responseContentType === 'application/json' && isObject(body)) {
       return ctx.json(body);
     } else if (body === undefined) {
       return ctx.newResponse(null);
@@ -109,15 +120,7 @@ export class HonoAdapter extends AbstractHttpAdapter<
   }
 
   private registerRoute(
-    method:
-      | 'all'
-      | 'get'
-      | 'post'
-      | 'put'
-      | 'delete'
-      | 'use'
-      | 'patch'
-      | 'options',
+    method: Method,
     pathOrHandler: string | HonoHandler,
     handler?: HonoHandler,
   ) {
@@ -193,18 +196,6 @@ export class HonoAdapter extends AbstractHttpAdapter<
 
     if (statusCode) {
       ctx.status(statusCode);
-    }
-
-    const responseContentType = await this.getHeader(ctx, 'Content-Type');
-
-    if (
-      !responseContentType?.startsWith('application/json') &&
-      body?.statusCode >= HttpStatus.BAD_REQUEST
-    ) {
-      Logger.warn(
-        "Content-Type doesn't match Reply body, you might need a custom ExceptionFilter for non-JSON responses",
-      );
-      this.setHeader(ctx, 'Content-Type', 'application/json');
     }
 
     ctx.res = await this.getBody(ctx, body);


### PR DESCRIPTION
## Summary

  This PR fixes an issue where responses set directly on `ctx.res` by NestJS interceptors are not properly returned, causing empty responses.

  ## Problem

  When using libraries like `@orpc/nest` that leverage NestJS interceptors to handle responses, the interceptor sets the response directly on `ctx.res` rather than returning a value from the controller. The current `getBody` implementation doesn't account for this pattern:

  1. An interceptor processes the request and sets `ctx.res` with the proper response
  2. The controller returns `undefined` (because the interceptor handled everything)
  3. `getBody` receives `body === undefined`
  4. The adapter returns `ctx.newResponse(null)` - an empty response

  ## Solution

  Added an early check in `getBody` to detect when `ctx.res` has already been populated by middleware/interceptors:

  ```typescript
  if (body === undefined && ctx.res && ctx.res.body !== null) {
    return ctx.res;
  }

  This ensures that pre-built responses are returned directly instead of being overwritten with an empty response.

  Testing

  Tested with @orpc/nest integration - endpoints now correctly return oRPC-serialized responses.